### PR TITLE
Cap utils

### DIFF
--- a/lib/capistrano/tasks/utils.rake
+++ b/lib/capistrano/tasks/utils.rake
@@ -1,0 +1,31 @@
+# Capistrano task utility methods
+# various capistrano variables should be accessible to these methods
+
+def client_port
+  host_settings['client_port']
+end
+
+def host_settings
+  # the `host` object should be accessible to this method
+  Settings.aws[host.hostname]
+end
+
+def install_java7
+  sudo(ubuntu_helper.java_oracle_license)
+  sudo(ubuntu_helper.java_7_oracle)
+end
+
+def install_java8
+  sudo(ubuntu_helper.java_oracle_license)
+  sudo(ubuntu_helper.java_8_oracle)
+end
+
+def ubuntu_helper
+  # the `current_path` should be accessible to this method
+  @ubuntu_helper ||= begin
+    helper = UbuntuHelper.new(current_path)
+    execute("mkdir -p #{helper.log_path}")
+    helper
+  end
+end
+

--- a/lib/ubuntu/ubuntu.rake
+++ b/lib/ubuntu/ubuntu.rake
@@ -1,14 +1,6 @@
 require_relative 'ubuntu_helper'
 
 namespace :ubuntu do
-  def ubuntu_helper
-    @ubuntu_helper ||= begin
-      helper = UbuntuHelper.new(current_path)
-      execute("mkdir -p #{helper.log_path}")
-      helper
-    end
-  end
-
   desc 'logs'
   task :logs do
     on roles(:ubuntu), in: :parallel do |host|

--- a/lib/ubuntu/ubuntu_helper.rb
+++ b/lib/ubuntu/ubuntu_helper.rb
@@ -87,5 +87,13 @@ class UbuntuHelper
     "#{script_path}/sbt.sh > #{log_path}/sbt.log"
   end
 
+  def zookeeper
+    "#{script_path}/zookeeper.sh > #{log_path}/zookeeper.log"
+  end
+
+  def zookeeper_upgrade
+    "apt-get install -y -q --only-upgrade zookeeper > #{log_path}/zookeeper_upgrade.log"
+  end
+
 end
 

--- a/lib/zookeeper/zookeeper.rake
+++ b/lib/zookeeper/zookeeper.rake
@@ -56,29 +56,19 @@ namespace :zookeeper do
   end
 
   namespace :service do
-    def host_settings
-      # the `host` object is accessible to this method
-      Settings.aws[host.hostname]
-    end
-
-    def client_port
-      host_settings['client_port']
-    end
-
     desc 'Install service'
     task :install do
       on roles(:zookeeper), in: :parallel do |host|
         # PuppetHelpers.puppet_apply('zookeeper.pp')
-        sudo("#{current_path}/lib/bash/debian/java_oracle_license.sh  > #{current_path}/log/bash_java_oracle_license.log")
-        sudo("#{current_path}/lib/bash/debian/java_8_oracle.sh > #{current_path}/log/bash_java_8_oracle.log")
-        sudo("#{current_path}/lib/bash/debian/zookeeper.sh > #{current_path}/log/bash_zookeeper.log")
+        install_java8
+        sudo(ubuntu_helper.zookeeper)
       end
     end
 
     desc 'Upgrade service'
     task :upgrade do
       on roles(:zookeeper), in: :parallel do |host|
-        sudo('apt-get install -y -q --only-upgrade zookeeper')
+        sudo(ubuntu_helper.zookeeper_upgrade)
       end
     end
 


### PR DESCRIPTION
- consolidate some capistrano utility methods into `lib/capistrano/tasks/utils.rake`
  - all the rake tasks can access them and they get access to rake variables
- use these util methods in ubuntu and other rake tasks
